### PR TITLE
Add inf version of the generator.

### DIFF
--- a/demo.inf
+++ b/demo.inf
@@ -12,6 +12,12 @@ ConditionImmunities=blinded, charmed, deafened, exhaustion, frightened, paralyze
 Senses=blindsight 60 ft. (blind beyond this radius), passive Perception 6
 Languages=None
 Challenge=1 (200 xp)
+Cha=10
+Con=10
+Dex=10
+Int=10
+Str=10
+Wis=10
 
 [Attributes]
 Anti Magic Susceptibility=The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster’s spell save DC or fall unconscious for 1 minute.

--- a/demo.inf
+++ b/demo.inf
@@ -1,6 +1,7 @@
 
 
 [Character]
+Name=Animated Armor
 Type=Medium Construct
 Alignment=Unaligned
 ArmorClass=18 (natural)
@@ -20,3 +21,6 @@ False Appearance=While the armor remains motionless, it is indistinguishable fro
 Multi Attack=The armor makes two melee attacks.
 Slam=Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage.
 
+
+[Faggotree]
+Skills = Can suck lots of dick

--- a/demo.inf
+++ b/demo.inf
@@ -1,0 +1,22 @@
+
+
+[Character]
+Type=Medium Construct
+Alignment=Unaligned
+ArmorClass=18 (natural)
+HitPoints=33 (6d8 + 6)
+Speed=25ft
+DamageImmunities=Poison, Psychic
+ConditionImmunities=blinded, charmed, deafened, exhaustion, frightened, paralyzed, petrified, poisoned
+Senses=blindsight 60 ft. (blind beyond this radius), passive Perception 6
+Languages=None
+Challenge=1 (200 xp)
+
+[Attributes]
+Anti Magic Susceptibility=The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster’s spell save DC or fall unconscious for 1 minute.
+False Appearance=While the armor remains motionless, it is indistinguishable from a normal suit of armor.
+
+[Actions]
+Multi Attack=The armor makes two melee attacks.
+Slam=Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage.
+

--- a/demo.inf
+++ b/demo.inf
@@ -28,5 +28,3 @@ Multi Attack=The armor makes two melee attacks.
 Slam=Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage.
 
 
-[Faggotree]
-Skills = Can suck lots of dick

--- a/template.html
+++ b/template.html
@@ -379,8 +379,8 @@
 
 <stat-block>
     <creature-heading>
-      <h1>{TYPE}</h1>
-      <h2>{ALIGNMENT}</h2>
+      <h1>{NAME}</h1>
+      <h2>{TYPE} {ALIGNMENT}</h2>
     </creature-heading>
 
     <top-stats>

--- a/template.html
+++ b/template.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html><head><link href="https://fonts.googleapis.com/css?family=Libre+Baskerville:700" rel="stylesheet" type="text/css"/><link href="http://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic" rel="stylesheet" type="text/css"/><meta charset="utf-8"/><title>Statblock example</title><style>
+      body {{
+        margin: 0;
+      }}
+
+      stat-block {{
+        /* A bit of margin for presentation purposes, to show off the drop
+        shadow. */
+        margin-left: 20px;
+        margin-top: 20px;
+      }}
+    </style></head><body><template id="tapered-rule">
+  <style>
+    svg {{
+      fill: #922610;
+      /* Stroke is necessary for good antialiasing in Chrome. */
+      stroke: #922610;
+      margin-top: 0.6em;
+      margin-bottom: 0.35em;
+    }}
+  </style>
+  <svg height="5" width="400">
+    <polyline points="0,0 400,2.5 0,5"></polyline>
+  </svg>
+</template><script>
+(function(window, document) {{
+  var elemName = 'tapered-rule';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="top-stats">
+  <style>
+    ::content * {{
+      color: #7A200D;
+    }}
+  </style>
+
+  <tapered-rule></tapered-rule>
+  <content></content>
+  <tapered-rule></tapered-rule>
+</template><script>
+(function(window, document) {{
+  var elemName = 'top-stats';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="creature-heading">
+  <style>
+    ::content > h1 {{
+      font-family: 'Libre Baskerville', 'Lora', 'Calisto MT',
+                   'Bookman Old Style', Bookman, 'Goudy Old Style',
+                   Garamond, 'Hoefler Text', 'Bitstream Charter',
+                   Georgia, serif;
+      color: #7A200D;
+      font-weight: 700;
+      margin: 0px;
+      font-size: 23px;
+      letter-spacing: 1px;
+      font-variant: small-caps;
+    }}
+
+    ::content > h2 {{
+      font-weight: normal;
+      font-style: italic;
+      font-size: 12px;
+      margin: 0;
+    }}
+  </style>
+  <content select="h1"></content>
+  <content select="h2"></content>
+</template><script>
+(function(window, document) {{
+  var elemName = 'creature-heading';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="abilities-block">
+  <style>
+    table {{
+      width: 100%;
+      border: 0px;
+      border-collapse: collapse;
+    }}
+    th, td {{
+      width: 50px;
+      text-align: center;
+    }}
+  </style>
+  <tapered-rule></tapered-rule>
+  <table>
+    <tbody><tr>
+      <th>STR</th>
+      <th>DEX</th>
+      <th>CON</th>
+      <th>INT</th>
+      <th>WIS</th>
+      <th>CHA</th>
+    </tr>
+    <tr>
+      <td id="str"></td>
+      <td id="dex"></td>
+      <td id="con"></td>
+      <td id="int"></td>
+      <td id="wis"></td>
+      <td id="cha"></td>
+    </tr>
+  </tbody></table>
+  <tapered-rule></tapered-rule>
+</template><script>
+(function(window, document) {{
+  function abilityModifier(abilityScore) {{
+    var score = parseInt(abilityScore, 10);
+    return Math.floor((score - 10) / 2);
+  }}
+
+  function formattedModifier(abilityModifier) {{
+    if (abilityModifier >= 0) {{
+      return '+' + abilityModifier;
+    }}
+    // This is an en dash, NOT a "normal" dash. The minus sign needs to be more
+    // visible.
+    return '–' + Math.abs(abilityModifier);
+  }}
+
+  function abilityText(abilityScore) {{
+    return [String(abilityScore),
+            ' (',
+            formattedModifier(abilityModifier(abilityScore)),
+            ')'].join('');
+  }}
+
+  var elemName = 'abilities-block';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        var root = this.createShadowRoot().appendChild(clone);
+      }}
+    }},
+    attachedCallback: {{
+      value: function() {{
+        var root = this.shadowRoot;
+        for (var i = 0; i < this.attributes.length; i++) {{
+          var attribute = this.attributes[i];
+          var abilityShortName = attribute.name.split('-')[1];
+          root.getElementById(abilityShortName).textContent =
+             abilityText(attribute.value);
+        }}
+
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="property-block">
+  <style>
+    :host {{
+      margin-top: 0.3em;
+      margin-bottom: 0.9em;
+      line-height: 1.5;
+      display: block;
+    }}
+
+    ::content > h4 {{
+      margin: 0;
+      display: inline;
+      font-weight: bold;
+      font-style: italic;
+    }}
+
+    ::content > p:first-of-type {{
+      display: inline;
+      text-indent: 0;
+    }}
+
+    ::content > p {{
+      text-indent: 1em;
+      margin: 0;
+    }}
+  </style>
+  <content></content>
+</template><script>
+(function(window, document) {{
+  var elemName = 'property-block';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="property-line">
+  <style>
+    :host {{
+      line-height: 1.4;
+      display: block;
+      text-indent: -1em;
+      padding-left: 1em;
+    }}
+
+    ::content > h4 {{
+      margin: 0;
+      display: inline;
+      font-weight: bold;
+    }}
+
+    ::content > p:first-of-type {{
+      display: inline;
+      text-indent: 0;
+    }}
+
+    ::content > p {{
+      text-indent: 1em;
+      margin: 0;
+    }}
+  </style>
+  <content></content>
+</template><script>
+(function(window, document) {{
+  var elemName = 'property-line';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script><template id="stat-block">
+  <style>
+    .bar {{
+      height: 5px;
+      background: #E69A28;
+      border: 1px solid #000;
+      position: relative;
+      z-index: 1;
+    }}
+
+    :host {{
+      display: inline-block;
+    }}
+
+    #content-wrap {{
+      font-family: 'Noto Sans', 'Myriad Pro', Calibri, Helvetica, Arial,
+                    sans-serif;
+      font-size: 13.5px;
+      background: #FDF1DC;
+      padding: 0.6em;
+      padding-bottom: 0.5em;
+      border: 1px #DDD solid;
+      box-shadow: 0 0 1.5em #867453;
+
+      /* We don't want the box-shadow in front of the bar divs. */
+      position: relative;
+      z-index: 0;
+
+      /* Leaving room for the two bars to protrude outwards */
+      margin-left: 2px;
+      margin-right: 2px;
+
+      /* This is possibly overriden by next CSS rule. */
+      width: 400px;
+
+      -webkit-columns: 400px;
+         -moz-columns: 400px;
+              columns: 400px;
+      -webkit-column-gap: 40px;
+         -moz-column-gap: 40px;
+              column-gap: 40px;
+    }}
+
+    :host([data-two-column]) #content-wrap {{
+      /* One column is 400px and the gap between them is 40px. */
+      width: 840px;
+    }}
+
+    ::content > h3 {{
+      border-bottom: 1px solid #7A200D;
+      color: #7A200D;
+      font-size: 21px;
+      font-variant: small-caps;
+      font-weight: normal;
+      letter-spacing: 1px;
+      margin: 0;
+      margin-bottom: 0.3em;
+
+      break-before: column;
+      break-inside: avoid-column;
+      break-after: avoid-column;
+    }}
+
+    /* For user-level p elems. */
+    ::content > p {{
+      margin-top: 0.3em;
+      margin-bottom: 0.9em;
+      line-height: 1.5;
+    }}
+
+    /* Last child shouldn't have bottom margin, too much white space. */
+    ::content > *:last-child {{
+      margin-bottom: 0;
+    }}
+  </style>
+  <div class="bar"></div>
+  <div id="content-wrap">
+    <content></content>
+  </div>
+  <div class="bar"></div>
+</template><script>
+(function(window, document) {{
+  var elemName = 'stat-block';
+  var thatDoc = document;
+  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var proto = Object.create(HTMLElement.prototype, {{
+    createdCallback: {{
+      value: function() {{
+        var template = thisDoc.getElementById(elemName);
+        // If the attr() CSS3 function were properly implemented, we wouldn't
+        // need this hack...
+        if (this.hasAttribute('data-content-height')) {{
+          var wrap = template.content.getElementById('content-wrap');
+          wrap.style.height = this.getAttribute('data-content-height') + 'px';
+        }}
+        var clone = thatDoc.importNode(template.content, true);
+        this.createShadowRoot().appendChild(clone);
+      }}
+    }}
+  }});
+  thatDoc.registerElement(elemName, {{prototype: proto}});
+}})(window, document);
+</script>
+  
+
+
+<stat-block>
+    <creature-heading>
+      <h1>{TYPE}</h1>
+      <h2>{ALIGNMENT}</h2>
+    </creature-heading>
+
+    <top-stats>
+      <property-line>
+        <h4>Armor Class</h4>
+        <p>{ARMORCLASS}</p>
+      </property-line>
+      <property-line>
+        <h4>Hit Points</h4>
+        <p>{HITPOINTS}</p>
+      </property-line>
+      <property-line>
+        <h4>Speed</h4>
+        <p>{SPEED}</p>
+      </property-line>
+
+      <abilities-block data-cha="1" data-con="13" data-dex="11" data-int="1" data-str="14" data-wis="3"></abilities-block>
+
+      <property-line>
+        <h4>Damage Immunities</h4>
+        <p>{DAMAGEIMMUNITIES}</p>
+      </property-line>
+      <property-line>
+        <h4>Condition Immunities</h4>
+        <p>{CONDITIONIMMUNITIES}</p>
+      </property-line>
+      <property-line>
+        <h4>Senses</h4>
+        <p>{SENSES}</p>
+      </property-line>
+      <property-line>
+        <h4>Languages</h4>
+        <p>{LANGUAGES}</p>
+      </property-line>
+      <property-line>
+        <h4>Challenge</h4>
+        <p>{CHALLENGE}</p>
+      </property-line>
+    </top-stats>
+
+    {CUSTOM}
+
+  </stat-block>
+</body></html>

--- a/template.html
+++ b/template.html
@@ -397,7 +397,14 @@
         <p>{SPEED}</p>
       </property-line>
 
-      <abilities-block data-cha="1" data-con="13" data-dex="11" data-int="1" data-str="14" data-wis="3"></abilities-block>
+      <abilities-block
+        data-cha="{CHA}"
+        data-con="{CON}"
+        data-dex="{DEX}"
+        data-int="{INT}"
+        data-str="{STR}"
+        data-wis="{WIS}">
+      </abilities-block>
 
       <property-line>
         <h4>Damage Immunities</h4>

--- a/tools/inf-gen.py
+++ b/tools/inf-gen.py
@@ -1,3 +1,4 @@
+#from ConfigParser import ConfigParser
 from ConfigParser import ConfigParser
 import sys
 
@@ -29,7 +30,6 @@ def template_generator(configfile):
             custom += '  <p>%s</p>\n' % value
             custom += '</property-block>\n'
     character['CUSTOM'] = custom
-    print(character)
 
     with open(TEMPLATE_FILE, 'rb') as template:
         t = template.read()

--- a/tools/inf-gen.py
+++ b/tools/inf-gen.py
@@ -1,0 +1,51 @@
+from ConfigParser import ConfigParser
+import sys
+
+TEMPLATE_FILE='template.html'
+
+def _gen_free_sequence(section):
+    # Expects a list of (name, value) tuples as you get from section.items
+    pass
+
+def template_generator(configfile):
+    custom = ''
+    charconfig = ConfigParser()
+    with open(configfile, 'rb') as config:
+        charconfig.readfp(config)
+
+    character = {}
+    for name, value in charconfig.items('Character'):
+        character[name.upper()] = value
+
+    # Construct the custom strings for Attributes, and Actions.
+    # These are a bit more of a pain than the rest is all.
+    sections = charconfig.sections()
+    sections.remove('Character')
+    for section in sections:
+        custom += '<h3>%s</h3>\n' % section.title()
+        for name, value in charconfig.items(section):
+            custom += '<property-block>\n'
+            custom += '  <h4>%s</h4>\n' % name.title()
+            custom += '  <p>%s</p>\n' % value
+            custom += '</property-block>\n'
+    character['CUSTOM'] = custom
+    print(character)
+
+    with open(TEMPLATE_FILE, 'rb') as template:
+        t = template.read()
+        processed = t.format(
+            **character
+        )
+        print(processed)
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print("Please provide a config file name")
+        sys.exit(1)
+    elif len(sys.argv) >= 3:
+        print("ARRGHH TOO MANY, TOO MANY! I'M LOST")
+        sys.exit(2)
+    else:
+        template_generator(sys.argv[1])
+
+


### PR DESCRIPTION
This changes the configuration format to inf.

In the Character section, you have things that are the same to all Characters.

If you add other sections after that, they automatically are turned into property blocks with headers based on the heading of the inf section.

This should make it a bit easier to use for people, as they can just copy the inf, edit, and then generate. 

It also removes the need for template inlining and munging because you only need the one template.html.

Work to still be done is probably some more attribute use cases, code cleanup, template improvements, and filepath specification is a bit rough at the moment.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valloric/statblock5e/2)
<!-- Reviewable:end -->
