### PR TITLE
Removed http/https from external google styles to prevent mixed content warning

### DIFF
--- a/src/creature-heading.html
+++ b/src/creature-heading.html
@@ -1,4 +1,4 @@
-<link href='https://fonts.googleapis.com/css?family=Libre+Baskerville:700'
+<link href='//fonts.googleapis.com/css?family=Libre+Baskerville:700'
       rel='stylesheet' type='text/css'>
 
 <template id="creature-heading">

--- a/src/stat-block.html
+++ b/src/stat-block.html
@@ -1,4 +1,4 @@
-<link href='http://fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic'
+<link href='//fonts.googleapis.com/css?family=Noto+Sans:400,700,400italic,700italic'
       rel='stylesheet' type='text/css'>
 <template id="stat-block">
   <style>


### PR DESCRIPTION
Simply removed http/https so it will default to the current scheme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/statblock5e/3)
<!-- Reviewable:end -->
