### PR TITLE
Add cross-browser support (tested in Firefox and Safari)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# http://editorconfig.org
+
+# A special property that should be specified at the top of the file outside of
+# any sections. Set to true to stop .editor config file search on current file
+root = true
+
+[*]
+# Indentation style
+# Possible values - tab, space
+indent_style = space
+
+# Indentation size in single-spaced characters
+# Possible values - an integer, tab
+indent_size = 2
+tab_width = 2
+
+# Line ending file format
+# Possible values - lf, crlf, cr
+end_of_line = lf
+
+# File character encoding
+# Possible values - latin1, utf-8, utf-16be, utf-16le
+charset = utf-8
+
+# Denotes whether to trim whitespace at the end of lines
+# Possible values - true, false
+trim_trailing_whitespace = true
+
+# Denotes whether file should end with a newline
+# Possible values - true, false
+insert_final_newline = true

--- a/bower.json
+++ b/bower.json
@@ -1,18 +1,23 @@
 {
-    "name": "statblock5e",
-    "version": "0.0.4",
-    "description": "A web component for D&D 5E statblocks.",
-    "authors": [
-      "Val Markovic <val@markovic.io> (http://val.markovic.io)"
-    ],
-    "license": "Apache-2.0",
-    "main": "src/statblock5e.html",
-    "keywords": [
-        "D&D", "D&D5e", "web component"
-    ],
-    "ignore": [
-        "**/.*",
-        "node_modules",
-        "bower_components"
-    ]
+  "name": "statblock5e",
+  "version": "0.0.4",
+  "description": "A web component for D&D 5E statblocks.",
+  "authors": [
+    "Val Markovic <val@markovic.io> (http://val.markovic.io)"
+  ],
+  "license": "Apache-2.0",
+  "main": "src/statblock5e.html",
+  "keywords": [
+    "D&D",
+    "D&D5e",
+    "web component"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components"
+  ],
+  "dependencies": {
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.1.1"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,12 @@
 {
   "name": "statblock5e",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A web component for D&D 5E statblocks.",
   "authors": [
     "Val Markovic <val@markovic.io> (http://val.markovic.io)"
+  ],
+  "contributors": [
+    "sporeservantpub <sporeservant@gmail.com> (https://github.com/sporeservantpub)"
   ],
   "license": "Apache-2.0",
   "main": "src/statblock5e.html",

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,6 @@
     "bower_components"
   ],
   "dependencies": {
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.1.1"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#0.7.24"
   }
 }

--- a/demo-with-polyfills.html
+++ b/demo-with-polyfills.html
@@ -5,8 +5,7 @@
     <title>Statblock example</title>
 
     <!-- Load polyfills; note that "loader" will load these async -->
-    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <!-- <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script> -->
+    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
 
     <link rel="import" href="src/top-stats.html">
     <link rel="import" href="src/creature-heading.html">

--- a/demo-with-polyfills.html
+++ b/demo-with-polyfills.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Statblock example</title>
+
+    <!-- Load polyfills; note that "loader" will load these async -->
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <!-- <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script> -->
+
+    <link rel="import" href="src/top-stats.html">
+    <link rel="import" href="src/creature-heading.html">
+    <link rel="import" href="src/abilities-block.html">
+    <link rel="import" href="src/property-block.html">
+    <link rel="import" href="src/property-line.html">
+    <link rel="import" href="src/stat-block.html">
+
+    <style>
+      body {
+        margin: 0;
+      }
+
+      stat-block {
+        /* A bit of margin for presentation purposes, to show off the drop
+        shadow. */
+        margin-left: 20px;
+        margin-top: 20px;
+      }
+    </style>
+</head>
+<body>
+  <stat-block>
+    <creature-heading>
+      <h1>Animated Armor</h1>
+      <h2>Medium construct, unaligned</h2>
+    </creature-heading>
+
+    <top-stats>
+      <property-line>
+        <h4>Armor Class</h4>
+        <p>18 (natural armor)</p>
+      </property-line>
+      <property-line>
+        <h4>Hit Points</h4>
+        <p>33 (6d8 + 6)</p>
+      </property-line>
+      <property-line>
+        <h4>Speed</h4>
+        <p>25ft</p>
+      </property-line>
+
+      <abilities-block data-str="14"
+                       data-dex="11"
+                       data-con="13"
+                       data-int="1"
+                       data-wis="3"
+                       data-cha="1"></abilities-block>
+
+      <property-line>
+        <h4>Damage Immunities</h4>
+        <p>poison, psychic</p>
+      </property-line>
+      <property-line>
+        <h4>Condition Immunities</h4>
+        <p>blinded, charmed, deafened, exhaustion, frightened, paralyzed,
+          petrified, poisoned</p>
+      </property-line>
+      <property-line>
+        <h4>Senses</h4>
+        <p>blindsight 60 ft. (blind beyond this radius), passive Perception 6</p>
+      </property-line>
+      <property-line>
+        <h4>Languages</h4>
+        <p>—</p>
+      </property-line>
+      <property-line>
+        <h4>Challenge</h4>
+        <p>1 (200 XP)</p>
+      </property-line>
+    </top-stats>
+
+    <property-block>
+      <h4>Antimagic Susceptibility.</h4>
+      <p>The armor is incapacitated while in the area of an <i>antimagic
+        field</i>.  If targeted by <i>dispel magic</i>, the armor must succeed
+        on a Constitution saving throw against the caster’s spell save DC or
+        fall unconscious for 1 minute.</p>
+    </property-block>
+    <property-block>
+      <h4>False Appearance.</h4>
+      <p>While the armor remains motionless, it is indistinguishable from a
+        normal suit of armor.</p>
+    </property-block>
+
+    <h3>Actions</h3>
+
+    <property-block>
+      <h4>Multiattack.</h4>
+      <p>The armor makes two melee attacks.</p>
+    </property-block>
+
+    <property-block>
+      <h4>Slam.</h4>
+      <p><i>Melee Weapon Attack:</i> +4 to hit, reach 5 ft., one target.
+        <i>Hit:</i> 5 (1d6 + 2) bludgeoning damage.</p>
+    </property-block>
+  </stat-block>
+</body>
+</html>

--- a/src/abilities-block.html
+++ b/src/abilities-block.html
@@ -59,7 +59,7 @@
 
   var elemName = 'abilities-block';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/abilities-block.html
+++ b/src/abilities-block.html
@@ -65,7 +65,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        var root = this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     },
     attachedCallback: {

--- a/src/creature-heading.html
+++ b/src/creature-heading.html
@@ -31,7 +31,7 @@
 (function(window, document) {
   var elemName = 'creature-heading';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/creature-heading.html
+++ b/src/creature-heading.html
@@ -37,7 +37,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });

--- a/src/property-block.html
+++ b/src/property-block.html
@@ -31,7 +31,7 @@
 (function(window, document) {
   var elemName = 'property-block';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/property-block.html
+++ b/src/property-block.html
@@ -37,7 +37,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });

--- a/src/property-line.html
+++ b/src/property-line.html
@@ -30,7 +30,7 @@
 (function(window, document) {
   var elemName = 'property-line';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/property-line.html
+++ b/src/property-line.html
@@ -36,7 +36,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });

--- a/src/stat-block.html
+++ b/src/stat-block.html
@@ -107,7 +107,31 @@
           wrap.style.height = this.getAttribute('data-content-height') + 'px';
         }
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });

--- a/src/stat-block.html
+++ b/src/stat-block.html
@@ -90,7 +90,7 @@
 (function(window, document) {
   var elemName = 'stat-block';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/stat-block.html
+++ b/src/stat-block.html
@@ -3,9 +3,9 @@
 <template id="stat-block">
   <style>
     .bar {
-      height: 5px;
       background: #E69A28;
       border: 1px solid #000;
+      height: 5px;
       position: relative;
       z-index: 1;
     }
@@ -15,12 +15,15 @@
     }
 
     #content-wrap {
+      padding: 0.6em;
+    }
+
+    #box-wrap {
       font-family: 'Noto Sans', 'Myriad Pro', Calibri, Helvetica, Arial,
                     sans-serif;
       font-size: 13.5px;
       background: #FDF1DC;
-      padding: 0.6em;
-      padding-bottom: 0.5em;
+      margin-bottom: 0.5em;
       border: 1px #DDD solid;
       box-shadow: 0 0 1.5em #867453;
 
@@ -79,11 +82,13 @@
       margin-bottom: 0;
     }
   </style>
-  <div class="bar"></div>
-  <div id="content-wrap">
-    <content></content>
+  <div id="box-wrap">
+    <div class="bar"></div>
+    <div id="content-wrap">
+      <content></content>
+    </div>
+    <div class="bar"></div>
   </div>
-  <div class="bar"></div>
 </template>
 
 <script>

--- a/src/tapered-rule.html
+++ b/src/tapered-rule.html
@@ -23,7 +23,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });

--- a/src/tapered-rule.html
+++ b/src/tapered-rule.html
@@ -17,7 +17,7 @@
 (function(window, document) {
   var elemName = 'tapered-rule';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/tapered-rule.html
+++ b/src/tapered-rule.html
@@ -8,7 +8,7 @@
       margin-bottom: 0.35em;
     }
   </style>
-  <svg height="5" width="400">
+  <svg height="5" width="100%">
     <polyline points="0,0 400,2.5 0,5"/>
   </svg>
 </template>

--- a/src/top-stats.html
+++ b/src/top-stats.html
@@ -16,7 +16,7 @@
 (function(window, document) {
   var elemName = 'top-stats';
   var thatDoc = document;
-  var thisDoc = (thatDoc.currentScript || thatDoc._currentScript).ownerDocument;
+  var thisDoc = (thatDoc._currentScript || thatDoc.currentScript).ownerDocument;
   var proto = Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function() {

--- a/src/top-stats.html
+++ b/src/top-stats.html
@@ -22,7 +22,31 @@
       value: function() {
         var template = thisDoc.getElementById(elemName);
         var clone = thatDoc.importNode(template.content, true);
-        this.createShadowRoot().appendChild(clone);
+        var shadowRoot = this.createShadowRoot();
+
+        if (window.WebComponents && window.WebComponents.ShadowCSS) {
+          // Some things like ::content and ::host, for example, can't be shimmed.
+          var elem = template.content.getElementsByTagName('style')[0];
+
+          // Note: template.content only exists the first time createdCallback runs.
+          // On subsequent calls, elem will be undefined and it doesn't matter, because
+          // the styles will have already been properly applied. I am not sure whether
+          // or not this is intentional, but the v0 lifecycle methods do not have a good
+          // clean way to handle this.
+          // So we do this the first time, and that's it.
+          if (elem) {
+            var style = elem.textContent;
+            style = style.replace(/::content >/g, '');
+            style = style.replace(/:host /g, elemName);
+            shadowRoot.innerHTML = `<style>${style}<style>`;
+            WebComponents.ShadowCSS.shimStyling(
+              template.content,
+              this.tagName
+            );
+          }
+        }
+
+        shadowRoot.appendChild(clone);
       }
     }
   });


### PR DESCRIPTION
This is completely opt-in - there is a demo which illustrates how to load the polyfill. If people want crossbrowser, they just need to use the <script> tag like in the demo.

Unfortunately v0 is really nasty to deal with, so there were a few manual CSS hacks necessary

I am planning to update this to WebComponents V1 spec in the next few weeks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/statblock5e/4)
<!-- Reviewable:end -->
